### PR TITLE
Feat: visit line number

### DIFF
--- a/src/main/java/edu/usb/argosinstrumentation/CoverageAdapter/CodeInjecter.java
+++ b/src/main/java/edu/usb/argosinstrumentation/CoverageAdapter/CodeInjecter.java
@@ -1,6 +1,7 @@
 package edu.usb.argosinstrumentation.CoverageAdapter;
 
 import lombok.Getter;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -16,5 +17,19 @@ public class CodeInjecter extends MethodVisitor implements Opcodes{
         this.methodDesc = desc;
         this.className = className;
     }
-}
 
+    @Override
+    public void visitLineNumber(int line, Label start) {
+        mv.visitLdcInsn(className);
+        mv.visitLdcInsn(methodName);
+        mv.visitLdcInsn(methodDesc);
+        mv.visitIntInsn(SIPUSH, line);
+        mv.visitMethodInsn(
+                INVOKESTATIC,
+                "driver/CoverageCollect",
+                "collect",
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V",
+                false);
+        super.visitLineNumber(line, start);
+    }
+}


### PR DESCRIPTION
The visitLineNumber method was overwritten in an ASM visitor to instrument the bytecode with calls to the static method CoverageCollect.collect. The instrumentation records the class name, the method, its description, and the line number executed. 